### PR TITLE
Adding optional subsection numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ A definition knows following options:
 	Position of the title. Not available for tables and figures. For tables use the CSS attribute *caption-side* instead.  
 	Default: 'top'
 
+* `numbering-level` (Integer)
+    Maximum depth to number blocks by subsection. For example, '2' would number blocks as 1.1.A, 1.1.B, 1.2.A, etc.
+	Default: 1 
+
+* `numbering-style` ({arabic|roman|Roman|alpha|Alpha})
+    Style to use for section numbering.
+    Default: arabic
+
 # Use
 ## Directive
 


### PR DESCRIPTION
This adds the ability to number by subsections.  For example: 2.1.A, 2.1.B, 2.2.A, 2.2.1.A, etc.  The final index is always returned as letters in "Excel Column Heading" format, so Z is followed by AA, AB, etc.  To configure a numbered block type to use subsection numbering, add the key:value 'subsections':True to the numbered_blocks definitions in the conf.py file.